### PR TITLE
Assume text is a certificate if no header and footer

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,12 @@ async function runAndShowOpenSSLCmd(command: string) {
 	if (!editor) {
 		return;
 	}
-	let result = openssl.stdin(editor.document.getText()).cmd(command).exec();
+	let pem = editor.document.getText();
+        // Check if the required PEM header and footer exist, if not assume the document contains a certificate
+        if (!pem.startsWith('-----') && !pem.endsWith('-----')){
+            pem = '-----BEGIN CERTIFICATE-----\n' + pem + '-----END CERTIFICATE-----';
+        }
+        let result = openssl.stdin(pem).cmd(command).exec();
 	let output = result.stdout;
 	if(result.status !== 0) {
 		output = result.stderr;


### PR DESCRIPTION
If the editor text does not contain a proper header and footer (-----BEGIN *----- ... -----END *-----), Assume the editor contains a PEM encoded certificate.  Otherwise without manually adding in the header and footer lines, an error is thrown, because the text cannot be interpreted properly by OpenSSL.